### PR TITLE
Adjust scaling behavior for results image

### DIFF
--- a/public/web_app.html
+++ b/public/web_app.html
@@ -2421,6 +2421,14 @@
                     this.panzoomInstance.reset();
                 }
                 this.image.src = src;
+                
+                // Force scale to exactly 1 (100%) after image loads
+                this.image.onload = () => {
+                    if (this.panzoomInstance) {
+                        this.panzoomInstance.zoom(1, { animate: false });
+                        this.panzoomInstance.pan(0, 0, { animate: false });
+                    }
+                };
             }
         }
 


### PR DESCRIPTION
This pull request introduces an enhancement to the image viewer functionality in `public/web_app.html`. The main change ensures that whenever a new image is loaded, its zoom and pan state are reset to a default view for a consistent user experience.

**Image viewer improvements:**

* Added logic to force the zoom level to 1 (100%) and pan position to (0, 0) immediately after an image finishes loading, ensuring the image is displayed at its default scale and position.